### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/medo-portfolio/',
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- configure Vite with `base: '/medo-portfolio/'`

## Testing
- `npm run build`
- `npm run deploy` *(fails: requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68444dbd374c83339b5e35468f7eed90